### PR TITLE
Fix call to compare and swap.

### DIFF
--- a/bitmap.h
+++ b/bitmap.h
@@ -46,7 +46,7 @@ class Bitmap {
     do {
       old_val = *loc;
       new_val = old_val | ((uint64_t) 1l << bit_offset(pos));
-    } while (!compare_and_swap(loc, old_val, new_val));
+    } while (!compare_and_swap(*loc, old_val, new_val));
   }
 
   bool get_bit(size_t pos) {

--- a/reader.h
+++ b/reader.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <sstream>
 #include <type_traits>
 
 #include "graph.h"
@@ -70,6 +71,31 @@ class Reader {
     return el;
   }
 
+  EdgeList ReadInGraph(std::ifstream &in) {
+    EdgeList el;
+    NodeID_ NodeNum;
+    NodeID_ EdgeNum;
+    NodeID_ u;
+    std::string line;
+    NodeWeight<NodeID_, WeightT_> v;
+
+    std::getline(in, line, '\n');
+    std::istringstream headlineStream(line);
+    headlineStream >> NodeNum >> EdgeNum;
+
+    for (NodeID_ i = 0; i < NodeNum; i++) {
+      std::string eline;
+      std::getline(in, eline);
+      std::istringstream lineStream(eline);
+
+      while (!lineStream.eof()) {
+        lineStream >> u;
+        el.push_back(Edge(i, u-1));
+      }
+    }
+    return el;
+  }
+
   EdgeList ReadFile(bool &needs_weights) {
     Timer t;
     t.Start();
@@ -88,6 +114,9 @@ class Reader {
     } else if (suffix == ".gr") {
       needs_weights = false;
       el = ReadInGR(file);
+    } else if (suffix == ".graph") {
+      needs_weights = false;
+      el = ReadInGraph(file);
     } else {
       std::cout << "Unrecognized suffix: " << suffix << std::endl;
       std::exit(-3);

--- a/tc.cc
+++ b/tc.cc
@@ -85,6 +85,6 @@ int main(int argc, char* argv[]) {
     return -1;
   Builder b(cli);
   Graph g = b.MakeGraph();
-  BenchmarkFunc(cli, g, Hybrid, PrintTriangleStats);
+  BenchmarkFunc(cli, g, OrderedCount, PrintTriangleStats);
   return 0;
 }


### PR DESCRIPTION
BFS was hanging here because the compare_and_swap template was comparing
old_val with the value of loc (the pointer it self).

Passing loc as first argument makes the compiler instantiate compare_and_swap
with T=int \* but then the function call __sync_bool_compare_and_swap as:

  __sync_bool_compare_and_swap(&x, old_val, new_val);

This means that the type of the first argument is int *\* which is wrong.

There is one more issue still to address. The family of functions __sync_*
works only with primitive types and templates in platform_atomics.h do not
address this issue.
