### PR TITLE
Fix compare_and_swap call in bitmap

### DIFF
--- a/bitmap.h
+++ b/bitmap.h
@@ -46,7 +46,7 @@ class Bitmap {
     do {
       old_val = *loc;
       new_val = old_val | ((uint64_t) 1l << bit_offset(pos));
-    } while (!compare_and_swap(loc, old_val, new_val));
+    } while (!compare_and_swap(*loc, old_val, new_val));
   }
 
   bool get_bit(size_t pos) {


### PR DESCRIPTION
BFS was hanging here because the compare_and_swap template was comparing
old_val with the value of loc (the pointer it self).

Passing loc as first argument makes the compiler instantiate compare_and_swap
with T=int \* but then the function call __sync_bool_compare_and_swap as:

__sync_bool_compare_and_swap(&x, old_val, new_val);

This means that the type of the first argument is int *\* which is wrong.

There is one more issue still to address. The family of functions __sync_*
works only with primitive types and templates in platform_atomics.h do not
address this issue.
