### PR TITLE
Add reference to Spack package in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Execute the benchmark suite:
 
     $ make bench-run
 
+Spack
+-----
+The GAP Benchmark Suite is also included in the [Spack](https://spack.io) package manager. To install:
+
+    $ spack install gapbs
+
 
 How to Cite
 -----------


### PR DESCRIPTION
There is a Spack package for the benchmark suite, so this PR adds information about it in the README.

See the [package.py](https://github.com/spack/spack/blob/54f97d1dec8df18b3d34144f38760abd9a7cc5b4/var/spack/repos/builtin/packages/gapbs/package.py) in the main [spack/spack](https://github.com/spack/spack) repo.