### PR TITLE
[test] bugfix: add a missing dependency to allow parallel test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ matrix:
       env: CXX=clang++-3.7 SERIAL=1
 script:
   - make -j
-  - make test
+  - make -j test

--- a/test/test.mk
+++ b/test/test.mk
@@ -73,7 +73,7 @@ test-load-%: test/out/load-%.out
 # Trivally small graph, will add benchmark graphs
 TEST_GRAPH ?= g10
 
-test/out/verify-%-$(TEST_GRAPH).out: %
+test/out/verify-%-$(TEST_GRAPH).out: test/out %
 	./$* -$(TEST_GRAPH) -vn1 > $@
 
 .SECONDARY:


### PR DESCRIPTION
This bugfix addresses issue #17 .