### PR TITLE
Fixed casting bug in CC

### DIFF
--- a/src/cc.cc
+++ b/src/cc.cc
@@ -85,7 +85,7 @@ NodeID SampleFrequentElement(const pvector<NodeID>& comp,
   float frac_of_graph = static_cast<float>(most_frequent->second) / num_samples;
   std::cout
     << "Skipping largest intermediate component (ID: " << most_frequent->first
-    << ", approx. " << static_cast<int>(frac_of_graph) * 100
+    << ", approx. " << static_cast<int>(frac_of_graph * 100)
     << "% of the graph)" << std::endl;
   return most_frequent->first;
 }


### PR DESCRIPTION
The value of frac_of_graph is between 0 and 1 so casting it to int gives 0 every time. I changed it so the multiplication by 100 is done before the casting.

Example results before the change:
```
$ ./cc -f test/graphs/4.el  -n1
Read Time:           0.00141
Build Time:          0.00018
Graph has 14 nodes and 53 directed edges for degree: 3
Skipping largest intermediate component (ID: 0, approx. 0% of the graph)
Trial Time:          0.00031
Average Time:        0.00031
```

Example results after the change:
```
$ ./cc -f test/graphs/4.el  -n1
Read Time:           0.00078
Build Time:          0.00027
Graph has 14 nodes and 53 directed edges for degree: 3
Skipping largest intermediate component (ID: 0, approx. 86% of the graph)
Trial Time:          0.00036
Average Time:        0.00036
```