### PR TITLE
[tc] fix _GLIBCXX_PARALLEL with SERIAL=1

### DIFF
--- a/src/tc.cc
+++ b/src/tc.cc
@@ -2,7 +2,9 @@
 // See LICENSE.txt for license details
 
 // Encourage use of gcc's parallel algorithms (for sort for relabeling)
-#define _GLIBCXX_PARALLEL
+#ifdef _OPENMP
+  #define _GLIBCXX_PARALLEL
+#endif
 
 #include <algorithm>
 #include <cinttypes>


### PR DESCRIPTION
When compiling tc.cc with SERIAL=1, -fopenmp flag is ignored. So the compilation flag _GLIBCXX_PARALLEL generates linking stage errors such as "undefined reference to `omp_get_max_threads'". So I added a preprocessor for checking OpenMP is currently included at tc.cc.