### PR TITLE
[converter] allow '#' as comment character in edge list parsing

### DIFF
--- a/src/reader.h
+++ b/src/reader.h
@@ -50,6 +50,16 @@ class Reader {
   EdgeList ReadInEL(std::ifstream &in) {
     EdgeList el;
     NodeID_ u, v;
+
+    char c;
+    do {
+      c = in.peek();
+      if (c == '#') {
+        in.ignore(200, '\n');
+        std::cout << c << " ignoring comment" << std::endl;
+      }
+    } while (c == '#');
+
     while (in >> u >> v) {
       el.push_back(Edge(u, v));
     }
@@ -60,6 +70,16 @@ class Reader {
     EdgeList el;
     NodeID_ u;
     NodeWeight<NodeID_, WeightT_> v;
+
+    char c;
+    do {
+      c = in.peek();
+      if (c == '#') {
+        in.ignore(200, '\n');
+        std::cout << c << " ignoring comment" << std::endl;
+      }
+    } while (c == '#');
+
     while (in >> u >> v) {
       el.push_back(Edge(u, v));
     }


### PR DESCRIPTION
Many people download graphs from the Stanford SNAP database. These are edgelist files (.el) however they contain some comments as a header. Manually spicing out the first four lines of a 32GB file is painful, so here is a quick way to allow `converter` to work on the file without modification. 

Sample test and output:

```
$ cat > foo.el
# Undirected graph: ../../data/output/friendster.txt
# Friendster
# Nodes: 65608366 Edges: 1806067135
# FromNodeId    ToNodeId
101     102
121     104
131     107
141     125
101     165
101     168
151     170
101     176
161     180
101     181
191     182
102     209
103     210
101     248
101     306
104     329
105     330
106     340
^D

$ ./converter -f foo.el -b foo.sg
# ignoring comment
# ignoring comment
# ignoring comment
# ignoring comment
Read Time:           0.00448
Build Time:          0.00343
Graph has 341 nodes and 18 directed edges for degree: 0
```